### PR TITLE
EmployeePairs-2 - Updated to .NET 8 (LTS), updated packages to latest versions

### DIFF
--- a/EmployeePairs/webapi/webapi.csproj
+++ b/EmployeePairs/webapi/webapi.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.5" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.16" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.3" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
The webapi project is using the outdated and out of support (i.e. end-of-life) version .NET 7.

In this branch I have updated the version to the LTS (Long Term Support) release .NET 8, and the NuGet package references to latest versions compatible with .NET 8.